### PR TITLE
Fix: correct inverted logic in CursorPagePagination.hasNextPage()

### DIFF
--- a/src/core/pagination.ts
+++ b/src/core/pagination.ts
@@ -194,7 +194,7 @@ export class CursorPagePagination<Item>
   }
 
   override hasNextPage(): boolean {
-    if (this.done === false) {
+    if (this.done === true) {
       return false;
     }
 


### PR DESCRIPTION
BUG-	Inverted logic in hasNextPage() - done === false should return true