### PR TITLE
chore(mcp): track latest dodopayments-mcp in cloudflare-worker

### DIFF
--- a/packages/mcp-server/cloudflare-worker/package.json
+++ b/packages/mcp-server/cloudflare-worker/package.json
@@ -25,8 +25,8 @@
     "@modelcontextprotocol/sdk": "1.28.0",
     "agents": "~0.8.7",
     "hono": "^4.12.4",
-    "dodopayments-mcp": "2.31.2",
-    "dodopayments": "^2.31.2"
+    "dodopayments-mcp": "latest",
+    "dodopayments": "latest"
   },
   "// overrides": "agents pins @modelcontextprotocol/sdk exactly; the three override blocks below force npm/yarn/pnpm to dedupe to that same version. Keep all four @modelcontextprotocol/sdk values in sync. See src/index.ts for the full rationale.",
   "overrides": {


### PR DESCRIPTION
## Summary

Points the Cloudflare worker's `dodopayments-mcp` and `dodopayments` dependencies at the npm **`latest`** dist-tag, so the worker always installs the newest published MCP server (currently `2.34.0`) rather than a fixed version.

The worker was previously pinned to `2.31.2` (the earlier production hotfix, `5bcbb32`).

```diff
-    "dodopayments-mcp": "2.31.2",
-    "dodopayments": "^2.31.2"
+    "dodopayments-mcp": "latest",
+    "dodopayments": "latest"
```

## Compatibility verification (against current `latest` = 2.34.0)

The worker hooks into internal MCP/SDK APIs, so this was checked before changing:

- **SDK dedupe preserved** — `@modelcontextprotocol/sdk` still resolves to a single `1.28.0` copy (no duplicate under `agents/` or `dodopayments-mcp/`), kept in sync with `agents@0.8.7`'s pin per the rationale in `src/index.ts`. The `instanceof McpServer` check in `initMcpServer` remains valid.
- **API surface intact** — `initMcpServer` / `newMcpServer` exports and signatures, `McpOptions` (`includeCodeTool`, `docsSearchMode: 'local'`), and the SDK's `_requestHandlers` map (the handler-wrap target for the self-hosted `execute` tool) are unchanged. Both `2.31.2` and `2.34.0` require `@modelcontextprotocol/sdk@^1.27.1`.

## Local testing (`wrangler dev`, Worker Loader binding active)

| Test | Result |
| --- | --- |
| `tools/list` | ✅ `search_docs, execute` |
| `execute` (Worker Loader isolate runs the SDK) | ✅ `client.payments.list` → `{"count":2}` |
| `throw` | ✅ surfaces as `isError: true` |

`typecheck` passes; isolate bundle rebuilds cleanly; **zero** init-guard throws in the dev log.

## ⚠️ Determinism caveat

Using the `latest` dist-tag means the resolved version is whatever is newest **at install/deploy time**. Because this worker has **no committed lockfile**, each deploy is non-reproducible: a future `dodopayments-mcp` release could change behavior (or break the `_requestHandlers` handler-wrap the self-hosted `execute` tool depends on) on the next production deploy with no PR. If reproducible deploys are preferred, a fixed version (e.g. `2.34.0`) + committed lockfile would be safer. Tagging `latest` per the maintainer's request.

## Deploy note

This updates the worker's source spec only. It reaches production on the next deploy (`workflow_dispatch` or release), consistent with the existing deploy flow.
