### PR TITLE
Add package support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "main": "dist/index.js",
   "type": "commonjs",
   "repository": "github:dodopayments/dodopayments-typescript",
+  "bugs": {
+    "url": "https://github.com/dodopayments/dodopayments-typescript/issues"
+  },
+  "homepage": "https://github.com/dodopayments/dodopayments-typescript#readme",
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "files": [

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -12,6 +12,9 @@
     "directory": "packages/mcp-server"
   },
   "homepage": "https://github.com/dodopayments/dodopayments-typescript/tree/main/packages/mcp-server#readme",
+  "bugs": {
+    "url": "https://github.com/dodopayments/dodopayments-typescript/issues"
+  },
   "license": "Apache-2.0",
   "packageManager": "yarn@1.22.22",
   "private": false,


### PR DESCRIPTION
## Summary
- add npm `bugs` and `homepage` metadata for the `dodopayments` package
- add npm `bugs` metadata for the `dodopayments-mcp` package
- leave runtime code, dependencies, exports, generated output, lockfile, and package versions unchanged

## Verification
- Node package manifest assertion for `package.json`
- Node package manifest assertion for `packages/mcp-server/package.json`
- `git diff --check`
- `npm pack --dry-run --ignore-scripts --json` from the root package
- `npm pack --dry-run --ignore-scripts --json` from `packages/mcp-server`

Note: `npm pack` for `packages/mcp-server` emits npm's existing `gitignore-fallback` warning because the package has no `.npmignore`; the dry run still succeeds and includes `package.json`.