### PR TITLE
fix(mcp/cloudflare-worker): stop per-session OAuth re-auth (upgrade workers-oauth-provider 0.0.5 -> 0.8.0)

### DIFF
--- a/packages/mcp-server/cloudflare-worker/package.json
+++ b/packages/mcp-server/cloudflare-worker/package.json
@@ -21,7 +21,7 @@
     "wrangler": "^4.59.1"
   },
   "dependencies": {
-    "@cloudflare/workers-oauth-provider": "^0.0.5",
+    "@cloudflare/workers-oauth-provider": "^0.8.0",
     "@modelcontextprotocol/sdk": "1.28.0",
     "agents": "~0.8.7",
     "hono": "^4.12.4",

--- a/packages/mcp-server/cloudflare-worker/scripts/oauth-diag.sh
+++ b/packages/mcp-server/cloudflare-worker/scripts/oauth-diag.sh
@@ -3,6 +3,11 @@
 # determines whether MCP clients are forced to re-authorize per session.
 # Usage: bash scripts/oauth-diag.sh <BASE_URL>
 # Requires DODO_TEST_KEY (test_mode key) in the environment.
+#
+# NOTE: this harness is tightly coupled to the current consent-flow HTML — it scrapes
+# the `oauthReqInfo` hidden field out of the /authorize page and the `code=` link out
+# of the /approve response. If src/utils.ts changes that markup (field names, form
+# shape), update the grep/sed extraction in get_code()/reg_and_req() accordingly.
 set -uo pipefail
 BASE="${1:?usage: oauth-diag.sh <BASE_URL>}"; KEY="${DODO_TEST_KEY:?set DODO_TEST_KEY}"
 

--- a/packages/mcp-server/cloudflare-worker/scripts/oauth-diag.sh
+++ b/packages/mcp-server/cloudflare-worker/scripts/oauth-diag.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# OAuth re-auth diagnostic harness. Characterizes server-side behavior that
+# determines whether MCP clients are forced to re-authorize per session.
+# Usage: bash scripts/oauth-diag.sh <BASE_URL>
+# Requires DODO_TEST_KEY (test_mode key) in the environment.
+set -uo pipefail
+BASE="${1:?usage: oauth-diag.sh <BASE_URL>}"; KEY="${DODO_TEST_KEY:?set DODO_TEST_KEY}"
+
+hr() { printf '\n========== %s ==========\n' "$1"; }
+
+# Register a public client (auth method none). Echoes client_id.
+register() {
+  local redirect="$1"
+  curl -s -X POST "$BASE/register" -H 'content-type: application/json' \
+    -d "{\"client_name\":\"diag\",\"redirect_uris\":[\"$redirect\"],\"token_endpoint_auth_method\":\"none\",\"grant_types\":[\"authorization_code\",\"refresh_token\"],\"response_types\":[\"code\"]}"
+}
+
+# Full authorize -> returns "code" for a given client_id + redirect_uri.
+# The code arrives URL-encoded in the redirect href; decode it so the caller can
+# re-encode once via --data-urlencode (double-encoding corrupts the code -> invalid_grant).
+get_code() {
+  local cid="$1" redirect_enc="$2"
+  local req raw
+  req=$(curl -s "$BASE/authorize?client_id=$cid&redirect_uri=$redirect_enc&response_type=code&state=x&scope=" \
+    | grep -oE 'name="oauthReqInfo" value="[^"]*"' | head -1 | sed 's/.*value="//;s/"$//' | sed 's/&quot;/"/g')
+  raw=$(curl -s -X POST "$BASE/approve" --data-urlencode "action=login_approve" --data-urlencode "oauthReqInfo=$req" \
+    --data-urlencode "clientopt_bearerToken=$KEY" --data-urlencode "clientopt_environment=test_mode" \
+    | grep -oE 'code=[^&"]+' | head -1 | sed 's/code=//')
+  node -e "process.stdout.write(decodeURIComponent(process.argv[1]||''))" "$raw"
+}
+
+# MCP initialize with a bearer token. Prints HTTP status + whether a session id came back.
+mcp_init() {
+  local acc="$1"
+  local hdr=/tmp/diag_mcp_hdr.txt
+  local status
+  status=$(curl -s -o /dev/null -w '%{http_code}' -X POST "$BASE/mcp" \
+    -H "authorization: Bearer $acc" -H 'content-type: application/json' \
+    -H 'accept: application/json, text/event-stream' -D "$hdr" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"diag","version":"1"}}}')
+  local sid
+  sid=$(grep -i '^mcp-session-id:' "$hdr" | tr -d '\r' | sed 's/.*: *//')
+  echo "HTTP=$status mcp-session-id=${sid:-<none>}"
+}
+
+echo "BASE=$BASE"
+
+hr "0. AUTH-SERVER METADATA (.well-known)"
+curl -s "$BASE/.well-known/oauth-authorization-server" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{try{const j=JSON.parse(d);console.log(JSON.stringify({grant_types_supported:j.grant_types_supported,token_endpoint_auth_methods_supported:j.token_endpoint_auth_methods_supported,code_challenge_methods_supported:j.code_challenge_methods_supported,registration_endpoint:j.registration_endpoint},null,2))}catch(e){console.log("RAW:",d.slice(0,400))}})'
+
+hr "1. REGISTER client A (redirect http://localhost:9999/cb)"
+REG_A=$(register "http://localhost:9999/cb")
+echo "$REG_A" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const j=JSON.parse(d);console.log(JSON.stringify({client_id:j.client_id,client_secret:j.client_secret??null,client_id_issued_at:j.client_id_issued_at,client_secret_expires_at:j.client_secret_expires_at,redirect_uris:j.redirect_uris},null,2))})'
+CID_A=$(echo "$REG_A" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>console.log(JSON.parse(d).client_id))')
+
+hr "2. FULL AUTH -> token response (expires_in / refresh_token presence)"
+CODE1=$(get_code "$CID_A" "http%3A%2F%2Flocalhost%3A9999%2Fcb")
+echo "authorization code: ${CODE1:0:12}..."
+TOK1=$(curl -s -X POST "$BASE/token" -d grant_type=authorization_code --data-urlencode "code=$CODE1" \
+  -d "client_id=$CID_A" -d "redirect_uri=http://localhost:9999/cb")
+echo "$TOK1" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const j=JSON.parse(d);console.log(JSON.stringify({token_type:j.token_type,expires_in:j.expires_in,has_access_token:!!j.access_token,has_refresh_token:!!j.refresh_token,scope:j.scope,refresh_prefix:(j.refresh_token||"").slice(0,8)},null,2))})'
+ACC1=$(echo "$TOK1" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>process.stdout.write(JSON.parse(d).access_token||""))')
+REF1=$(echo "$TOK1" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>process.stdout.write(JSON.parse(d).refresh_token||""))')
+
+hr "3. ACCESS-TOKEN REUSE across THREE fresh MCP sessions (new-conversation sim)"
+echo "session #1: $(mcp_init "$ACC1")"
+echo "session #2: $(mcp_init "$ACC1")"
+echo "session #3: $(mcp_init "$ACC1")"
+
+hr "4. REFRESH flow (grant_type=refresh_token) -> rotation?"
+RT1=$(curl -s -X POST "$BASE/token" -d grant_type=refresh_token --data-urlencode "refresh_token=$REF1" -d "client_id=$CID_A")
+echo "$RT1" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const j=JSON.parse(d);console.log(JSON.stringify({expires_in:j.expires_in,has_access_token:!!j.access_token,has_refresh_token:!!j.refresh_token,new_refresh_prefix:(j.refresh_token||"").slice(0,8),error:j.error,error_description:j.error_description},null,2))})'
+ACC2=$(echo "$RT1" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>process.stdout.write(JSON.parse(d).access_token||""))')
+REF2=$(echo "$RT1" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>process.stdout.write(JSON.parse(d).refresh_token||""))')
+echo "refreshed access token works in new MCP session: $(mcp_init "$ACC2")"
+
+hr "5. CONCURRENT-401 RACE sim: reuse the SAME (old) refresh token REF1 again"
+echo "(workers-oauth-provider rotates refresh tokens; a 2nd concurrent refresh with the stale token is MCP SDK #1760)"
+RT_OLD=$(curl -s -w '\n__HTTP__%{http_code}' -X POST "$BASE/token" -d grant_type=refresh_token --data-urlencode "refresh_token=$REF1" -d "client_id=$CID_A")
+echo "$RT_OLD" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const m=d.split("__HTTP__");const http=m[1]||"?";let body={};try{body=JSON.parse(m[0])}catch(e){}console.log(JSON.stringify({http,error:body.error,error_description:body.error_description,has_access_token:!!body.access_token},null,2))})'
+
+hr "5b. Is REF1 fully dead, or is the PREVIOUS rotation still valid (grace window)?"
+echo "REF1 (original) status shown above. Now confirm REF2 (latest) still works:"
+RT2=$(curl -s -w '\n__HTTP__%{http_code}' -X POST "$BASE/token" -d grant_type=refresh_token --data-urlencode "refresh_token=$REF2" -d "client_id=$CID_A")
+echo "$RT2" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const m=d.split("__HTTP__");console.log("REF2 -> HTTP",m[1]||"?");let b={};try{b=JSON.parse(m[0])}catch(e){}console.log(JSON.stringify({has_access_token:!!b.access_token,error:b.error},null,2))})'
+
+hr "6. REDIRECT_URI EPHEMERAL-PORT MISMATCH (register :9999, authorize :54321)"
+echo "Native apps (Claude Code / Codex) reuse a stored client_id but bind a NEW ephemeral localhost port each launch."
+echo "0.0.5 matches redirect_uri by exact string. Capturing /authorize response for the mismatched port:"
+MISMATCH=$(curl -s -w '\n__HTTP__%{http_code}' "$BASE/authorize?client_id=$CID_A&redirect_uri=http%3A%2F%2Flocalhost%3A54321%2Fcb&response_type=code&state=x&scope=")
+echo "$MISMATCH" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const m=d.split("__HTTP__");console.log("HTTP",m[1]||"?");const body=m[0]||"";const err=(body.match(/error[^<]*|invalid[^<]*|redirect[^<]*/i)||[])[0];console.log("snippet:",(err||body.replace(/\s+/g," ").slice(0,300)));})'
+
+hr "6b. CONTROL: same flow but with the CORRECT registered port :9999 succeeds"
+CTRL=$(curl -s -w '\n__HTTP__%{http_code}' "$BASE/authorize?client_id=$CID_A&redirect_uri=http%3A%2F%2Flocalhost%3A9999%2Fcb&response_type=code&state=x&scope=")
+echo "$CTRL" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const m=d.split("__HTTP__");console.log("HTTP",m[1]||"?","hasOauthReqInfo="+/oauthReqInfo/.test(m[0]||""));})'
+
+hr "7. UNKNOWN client_id at /token (DCR churn -> invalid_client?)"
+BOGUS=$(curl -s -w '\n__HTTP__%{http_code}' -X POST "$BASE/token" -d grant_type=refresh_token --data-urlencode "refresh_token=$REF2" -d "client_id=does-not-exist-0000")
+echo "$BOGUS" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const m=d.split("__HTTP__");console.log("HTTP",m[1]||"?");let b={};try{b=JSON.parse(m[0])}catch(e){b={raw:(m[0]||"").slice(0,200)}}console.log(JSON.stringify(b,null,2))})'
+
+hr "8. NO GRANT REVOCATION in 0.0.5: re-auth same key, confirm OLD access token still valid"
+CODE2=$(get_code "$CID_A" "http%3A%2F%2Flocalhost%3A9999%2Fcb")
+TOK3=$(curl -s -X POST "$BASE/token" -d grant_type=authorization_code --data-urlencode "code=$CODE2" \
+  -d "client_id=$CID_A" -d "redirect_uri=http://localhost:9999/cb")
+ACC3=$(echo "$TOK3" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>process.stdout.write(JSON.parse(d).access_token||""))')
+echo "new grant access token (ACC3) works: $(mcp_init "$ACC3")"
+echo "ORIGINAL refreshed token (ACC2) STILL works after new auth: $(mcp_init "$ACC2")"
+
+echo ""
+echo "========== DONE =========="

--- a/packages/mcp-server/cloudflare-worker/src/app.ts
+++ b/packages/mcp-server/cloudflare-worker/src/app.ts
@@ -8,6 +8,7 @@ import {
   renderAuthorizationApprovedContent,
   renderLoggedOutAuthorizeScreen,
   renderAuthorizationRejectedContent,
+  renderAuthorizeErrorContent,
   stableUserId,
 } from './utils';
 import type { AuthRequest, OAuthHelpers } from '@cloudflare/workers-oauth-provider';
@@ -36,16 +37,16 @@ export function makeOAuthConsent(config: ServerConfig) {
     } catch (err) {
       // parseAuthRequest throws on a malformed request or a redirect_uri that does
       // not match the client's registration. Without this catch the throw escapes as
-      // an opaque HTTP 500; return a clean 400 consent-error page instead. Log only
-      // the error message (never the raw request URL/query, which carry client
-      // identifiers) so production can tell a redirect mismatch apart from a KV/provider failure.
+      // an opaque HTTP 500; render a clean 400 error page (no form — there is no valid
+      // request to submit) instead. Log only the error message (never the raw request
+      // URL/query, which carry client identifiers) so production can tell a redirect
+      // mismatch apart from a KV/provider failure.
       console.warn('OAuth /authorize parse failed:', err instanceof Error ? err.message : String(err));
       return c.html(
         layout(
-          await renderLoggedOutAuthorizeScreen(config, {} as AuthRequest, {
-            formError:
-              'This authorization request is invalid. Please restart the connection from your MCP client.',
-          }),
+          await renderAuthorizeErrorContent(
+            'This authorization request is invalid. Please restart the connection from your MCP client.',
+          ),
           'Authorization',
           config,
         ),

--- a/packages/mcp-server/cloudflare-worker/src/app.ts
+++ b/packages/mcp-server/cloudflare-worker/src/app.ts
@@ -43,7 +43,8 @@ export function makeOAuthConsent(config: ServerConfig) {
       return c.html(
         layout(
           await renderLoggedOutAuthorizeScreen(config, {} as AuthRequest, {
-            formError: 'This authorization request is invalid. Please restart the connection from your MCP client.',
+            formError:
+              'This authorization request is invalid. Please restart the connection from your MCP client.',
           }),
           'Authorization',
           config,

--- a/packages/mcp-server/cloudflare-worker/src/app.ts
+++ b/packages/mcp-server/cloudflare-worker/src/app.ts
@@ -8,8 +8,9 @@ import {
   renderAuthorizationApprovedContent,
   renderLoggedOutAuthorizeScreen,
   renderAuthorizationRejectedContent,
+  stableUserId,
 } from './utils';
-import type { OAuthHelpers } from '@cloudflare/workers-oauth-provider';
+import type { AuthRequest, OAuthHelpers } from '@cloudflare/workers-oauth-provider';
 import { ServerConfig } from '.';
 
 export type Bindings = Env & {
@@ -29,7 +30,27 @@ export function makeOAuthConsent(config: ServerConfig) {
 
   // The /authorize page has a form that will POST to /approve
   app.get('/authorize', async (c) => {
-    const oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw);
+    let oauthReqInfo: AuthRequest;
+    try {
+      oauthReqInfo = await c.env.OAUTH_PROVIDER.parseAuthRequest(c.req.raw);
+    } catch (err) {
+      // parseAuthRequest throws on a malformed request or a redirect_uri that does
+      // not match the client's registration. Without this catch the throw escapes as
+      // an opaque HTTP 500; return a clean 400 consent-error page instead. Log only
+      // the error message (never the raw request URL/query, which carry client
+      // identifiers) so production can tell a redirect mismatch apart from a KV/provider failure.
+      console.warn('OAuth /authorize parse failed:', err instanceof Error ? err.message : String(err));
+      return c.html(
+        layout(
+          await renderLoggedOutAuthorizeScreen(config, {} as AuthRequest, {
+            formError: 'This authorization request is invalid. Please restart the connection from your MCP client.',
+          }),
+          'Authorization',
+          config,
+        ),
+        400,
+      );
+    }
 
     const content = await renderLoggedOutAuthorizeScreen(config, oauthReqInfo);
     return c.html(layout(content, 'Authorization', config));
@@ -84,14 +105,30 @@ export function makeOAuthConsent(config: ServerConfig) {
     const environment = String(clientProps.environment ?? '');
     const bearerToken = String(clientProps.bearerToken ?? '');
 
+    // The consent form's `required`/radio constraints are client-side only and are
+    // not a security boundary; a forged or malformed POST can submit an empty key or
+    // an environment outside ALLOWED_ENVIRONMENTS. Reject both before the grant is
+    // stored — otherwise an out-of-range environment short-circuits the probe below
+    // and a grant carrying unusable clientProps gets persisted.
+    if (!bearerToken || !ALLOWED_ENVIRONMENTS.includes(environment)) {
+      return c.html(
+        layout(
+          await renderLoggedOutAuthorizeScreen(config, oauthReqInfo, {
+            values: ALLOWED_ENVIRONMENTS.includes(environment) ? { environment } : {},
+            formError: 'Enter a valid API key and select a supported environment.',
+          }),
+          'Authorization',
+          config,
+        ),
+        400,
+      );
+    }
+
     // Validate the key against the chosen environment before the grant is stored,
     // so a test-key/live-mode (or vice versa) mismatch is caught here instead of
     // as an opaque 401 inside the `execute` tool later. Only a definitive
     // rejection blocks; transient/unverifiable results fall through.
-    if (
-      ALLOWED_ENVIRONMENTS.includes(environment) &&
-      (await probeApiKey(environment, bearerToken)) === 'rejected'
-    ) {
+    if ((await probeApiKey(environment, bearerToken)) === 'rejected') {
       const environmentLabel =
         config.clientProperties
           .find((p) => p.key === 'environment')
@@ -109,13 +146,9 @@ export function makeOAuthConsent(config: ServerConfig) {
       );
     }
 
-    // We don't have a real user ID, just tokens, so we generate a random one
-    // Make this some stable ID if you want to look up the user's grants later.
-    const generatedUserId = crypto.randomUUID();
-
     const { redirectTo } = await c.env.OAUTH_PROVIDER.completeAuthorization({
       request: oauthReqInfo,
-      userId: generatedUserId,
+      userId: await stableUserId(environment, bearerToken),
       metadata: {},
       scope: oauthReqInfo.scope,
       props: {

--- a/packages/mcp-server/cloudflare-worker/src/index.ts
+++ b/packages/mcp-server/cloudflare-worker/src/index.ts
@@ -19,7 +19,6 @@ import { ClientOptions } from 'dodopayments';
 import { McpOptions } from 'dodopayments-mcp/options';
 import { initMcpServer, newMcpServer } from 'dodopayments-mcp/server';
 import { configureLogger } from 'dodopayments-mcp/logger';
-import type { ExportedHandler } from '@cloudflare/workers-types';
 import { executeToolDescriptor, runExecute } from './execute-tool';
 
 type MCPProps = {
@@ -223,9 +222,7 @@ export type ClientProperty = {
 // Export the OAuth handler as the default
 export default new OAuthProvider({
   apiHandlers: {
-    // @ts-expect-error
     '/sse': MyMCP.serveSSE('/sse'), // legacy SSE
-    // @ts-expect-error
     '/mcp': MyMCP.serve('/mcp'), // Streaming HTTP
   },
   // Type assertion needed due to Headers type mismatch between Hono and @cloudflare/workers-types
@@ -234,4 +231,13 @@ export default new OAuthProvider({
   authorizeEndpoint: '/authorize',
   tokenEndpoint: '/token',
   clientRegistrationEndpoint: '/register',
+  // This provider defaults refresh tokens to 30 days and dynamically-registered
+  // clients to 90 days; letting either expire forces every MCP client to re-run
+  // the full browser authorization once the window lapses. Pin both to `undefined`
+  // (never expire) so only the 1h access token rotates and refresh keeps sessions
+  // alive indefinitely. Do NOT "simplify" these away — omitting them re-enables the
+  // 30d/90d defaults and reintroduces periodic re-authorization.
+  accessTokenTTL: 3600,
+  refreshTokenTTL: undefined,
+  clientRegistrationTTL: undefined,
 });

--- a/packages/mcp-server/cloudflare-worker/src/index.ts
+++ b/packages/mcp-server/cloudflare-worker/src/index.ts
@@ -225,9 +225,7 @@ export default new OAuthProvider({
     '/sse': MyMCP.serveSSE('/sse'), // legacy SSE
     '/mcp': MyMCP.serve('/mcp'), // Streaming HTTP
   },
-  // Type assertion needed due to Headers type mismatch between Hono and @cloudflare/workers-types
-  // At runtime, Hono's fetch handler is fully compatible with ExportedHandler
-  defaultHandler: makeOAuthConsent(serverConfig) as unknown as ExportedHandler,
+  defaultHandler: makeOAuthConsent(serverConfig),
   authorizeEndpoint: '/authorize',
   tokenEndpoint: '/token',
   clientRegistrationEndpoint: '/register',
@@ -236,7 +234,10 @@ export default new OAuthProvider({
   // the full browser authorization once the window lapses. Pin both to `undefined`
   // (never expire) so only the 1h access token rotates and refresh keeps sessions
   // alive indefinitely. Do NOT "simplify" these away — omitting them re-enables the
-  // 30d/90d defaults and reintroduces periodic re-authorization.
+  // 30d/90d defaults and reintroduces periodic re-authorization. Verified against
+  // @cloudflare/workers-oauth-provider 0.8.0: the constructor spreads
+  // `{ ...defaults, ...options }` and every TTL usage site gates on `!== void 0`, so
+  // an explicit `undefined` overrides the default rather than falling back to it.
   accessTokenTTL: 3600,
   refreshTokenTTL: undefined,
   clientRegistrationTTL: undefined,

--- a/packages/mcp-server/cloudflare-worker/src/utils.ts
+++ b/packages/mcp-server/cloudflare-worker/src/utils.ts
@@ -494,6 +494,28 @@ export const renderAuthorizationRejectedContent = async (redirectUrl: string) =>
   return renderApproveContent('Authorization rejected.', 'error', redirectUrl);
 };
 
+// Shown when /authorize cannot parse the request (e.g. a redirect_uri that does not
+// match the client's registration). It deliberately omits the consent form: there is
+// no valid oauthReqInfo to submit, so rendering the form would let a stray "Approve"
+// click POST `oauthReqInfo={}` and dead-end on a bare `INVALID LOGIN` 401.
+export const renderAuthorizeErrorContent = async (message: string) => html`
+  <div class="max-w-md mx-auto bg-white border border-border-secondary p-8 rounded-lg shadow-sm text-center">
+    <div class="mb-5">
+      <span
+        class="inline-flex items-center justify-center w-12 h-12 text-xl bg-error-bg text-error-text rounded-full"
+        >✗</span
+      >
+    </div>
+    <h1 class="text-xl font-heading font-semibold mb-2 text-text-primary">Authorization request invalid</h1>
+    <p class="mb-6 text-sm text-text-secondary">${message}</p>
+    <a
+      href="/"
+      class="inline-flex items-center justify-center h-10 px-4 font-heading font-medium text-sm rounded-lg border border-transparent bg-ink text-white transition-all duration-300 hover:bg-brand hover:text-ink hover:border-border-primary focus:outline-none focus:ring-2 focus:ring-brand-border focus:ring-offset-2"
+      >Return to Home</a
+    >
+  </div>
+`;
+
 export const parseApproveFormBody = async (
   body: {
     [x: string]: string | File;

--- a/packages/mcp-server/cloudflare-worker/src/utils.ts
+++ b/packages/mcp-server/cloudflare-worker/src/utils.ts
@@ -53,6 +53,21 @@ export const probeApiKey = async (environment: string, bearerToken: string): Pro
   }
 };
 
+// OAuthProvider keys every grant/token under `userId` and (since 0.8.0) revokes a
+// user's prior grants for the same client on re-auth. A stable id is therefore
+// required: a random id per authorization orphans grants and defeats that cleanup,
+// causing unbounded KV growth. Derive it as a SHA-256 hex digest of (environment,
+// key) so the same credentials always map to the same owner. The digest is one-way
+// (the raw key is never embedded), the NUL separator stops env/key boundary
+// collisions, and hex output guarantees no ':' — the character OAuthProvider uses
+// internally as a token field separator.
+export const stableUserId = async (environment: string, bearerToken: string): Promise<string> => {
+  const data = new TextEncoder().encode(`${environment}\u0000${bearerToken}`);
+  const digest = await crypto.subtle.digest('SHA-256', data);
+  const hex = [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, '0')).join('');
+  return `dodo_${hex}`;
+};
+
 export const layout = (content: HtmlEscapedString | string, title: string, config: ServerConfig) => html`
   <!doctype html>
   <html lang="en">


### PR DESCRIPTION
## Problem

Remote MCP clients (Codex app, Claude Code, opencode, the dodo-agent-plugin) re-ran the **full browser OAuth authorization on nearly every new conversation**.

## Root cause (reproduced locally against `wrangler dev`)

The worker ran `@cloudflare/workers-oauth-provider@0.0.5`. Two server-side issues:

1. **Redirect ephemeral-port 500.** 0.0.5 matched `redirect_uri` by exact string. Native apps reuse a stored `client_id` but bind a **new ephemeral localhost port** on each launch, so `parseAuthRequest` threw `Invalid redirect URI…`. Our `/authorize` handler didn't catch it → **HTTP 500** → the client couldn't complete auth → forced re-auth. This matches the reported clients (Codex app / Claude Code).
2. **No grant hygiene.** 0.0.5 had no grant revocation, and `userId: crypto.randomUUID()` per auth orphaned grants (unbounded KV growth).

> Note: within the 1h access-token TTL, the server does **not** require re-auth for a new session (verified: the same token initializes multiple MCP sessions, and refresh works). The remaining "every conversation" cases are **client-side token persistence** (mcp-remote `expires_at` handling, MCP SDK concurrent-refresh race / `saveTokens` swallowing) which cannot be fixed server-side. This PR fixes the server-side causes and removes the hard 500 that broke native apps.

## Changes

- **Upgrade `@cloudflare/workers-oauth-provider` `^0.0.5` → `^0.8.0`** — brings the localhost any-port redirect fix (`0.3.1`), `revokeExistingGrants` (`0.3.0`, default `true`), refresh retry-storm fix, and stricter spec compliance.
- **Pin TTLs** in the provider config: `accessTokenTTL: 3600`, `refreshTokenTTL: undefined`, `clientRegistrationTTL: undefined`. 0.8.0 defaults refresh tokens to 30d and DCR clients to 90d; pinning to `undefined` preserves 0.0.5 behavior (only the 1h access token expires) so the upgrade does **not** introduce a delayed re-auth regression. Verified in the 0.8.0 source that the constructor spreads `{...defaults, ...options}` and all sites gate on `!== void 0`, so explicit `undefined` disables expiry.
- **`try/catch` around `parseAuthRequest`** — malformed / mismatched requests now return a clean **400** consent-error page instead of a 500. Logs the error *message only* (never the URL/query) for prod diagnosis.
- **Stable `userId`** = `"dodo_" + sha256hex(environment + NUL + key)` (replaces random UUID) so 0.8.0 grant revocation actually works and grants stop accumulating. Colon-free by construction (the provider uses `:` as its token field separator).
- **Hard server-side validation in `/approve`** — reject empty `bearerToken` or out-of-range `environment` before storing the grant. The consent form's `required`/radio attributes are client-side only; previously a forged POST with an unknown environment skipped the key probe and persisted an unusable grant.
- **Cleanup:** drop the now-dead `@cloudflare/workers-types` import (0.8.0 has no deps; `ExportedHandler` is a wrangler-generated global already in `tsconfig` include) and two unused `@ts-expect-error` directives (0.8.0's `apiHandlers` types accept the handlers).

## Local verification (`wrangler dev`, local KV/DO)

`tsc --noEmit` + LSP clean. Via `scripts/oauth-diag.sh` and `scripts/probe.sh`:

| Check | Before (0.0.5) | After (0.8.0) |
|---|---|---|
| `tools/list` / `execute` / `search_docs` | ✅ | ✅ |
| redirect ephemeral-port mismatch (`:9999`→`:54321`) | **HTTP 500** | **HTTP 200** (consent renders) |
| non-localhost mismatch / malformed `/authorize` | HTTP 500 | **clean 400** (no stack) |
| same access token across 3 fresh MCP sessions | 200 | 200 |
| refresh + 2-token rotation window | works | works |
| re-auth then old grant's token (same key+client) | 200 (orphaned) | **401 (revoked)** |
| forged environment (`prod_mode`) / empty key in `/approve` | grant stored | **400, no grant** |

## Migration notes

- KV key shapes (`client:*`, `grant:<userId>:<grantId>`, `token:<userId>:<grantId>:*`) are compatible between 0.0.5 and 0.8.0, so **existing tokens keep working** after deploy (no forced re-auth).
- **Legacy random-`userId` grants remain orphaned** (different KV prefix) and never expire; stable revocation only applies to grants created after deploy. They fall out of use naturally.
- Deploy is gated on `release: published` / `workflow_dispatch` (not on merge), per the existing workflow.

## Notes for reviewers

- `scripts/oauth-diag.sh` is added as a sibling to the existing `scripts/probe.sh` — it's the reproduction/verification harness for this PR (reads `DODO_TEST_KEY` from env; no secret committed). Happy to drop it if you'd prefer it not live in the repo.
- The stable `userId` is an **unsalted** SHA-256 of `(environment, key)`. Since 0.8.0 tokens embed `userId`, the MCP client (which already holds the key) can see a stable fingerprint of its own key. This is acceptable for high-entropy Dodo keys; a Worker-secret **HMAC** would remove the fingerprint at the cost of secret management — left as optional future hardening.
- Client-side token-persistence causes are out of scope here (require client updates).
