### PR TITLE
fix(mcp/cloudflare-worker): raise access-token TTL to 24h to cut mcp-remote re-auth popups

### DIFF
--- a/packages/mcp-server/cloudflare-worker/src/index.ts
+++ b/packages/mcp-server/cloudflare-worker/src/index.ts
@@ -229,16 +229,22 @@ export default new OAuthProvider({
   authorizeEndpoint: '/authorize',
   tokenEndpoint: '/token',
   clientRegistrationEndpoint: '/register',
-  // This provider defaults refresh tokens to 30 days and dynamically-registered
-  // clients to 90 days; letting either expire forces every MCP client to re-run
-  // the full browser authorization once the window lapses. Pin both to `undefined`
-  // (never expire) so only the 1h access token rotates and refresh keeps sessions
-  // alive indefinitely. Do NOT "simplify" these away — omitting them re-enables the
-  // 30d/90d defaults and reintroduces periodic re-authorization. Verified against
-  // @cloudflare/workers-oauth-provider 0.8.0: the constructor spreads
-  // `{ ...defaults, ...options }` and every TTL usage site gates on `!== void 0`, so
-  // an explicit `undefined` overrides the default rather than falling back to it.
-  accessTokenTTL: 3600,
+  // Access tokens live 24h rather than the 1h default. Most clients reach this server via
+  // `mcp-remote`, which does not track token expiry locally and only refreshes AFTER the
+  // server 401s (geelen/mcp-remote#273); its refresh-on-401 path frequently loses a race
+  // with the host restarting the process, surfacing a fresh browser-auth popup. A 1h TTL
+  // triggers that ~24x/day; 24h cuts it to ~1x/day. The larger access-token leak window is
+  // acceptable here because refresh tokens are already non-expiring (standing exposure is
+  // unchanged) and grants stay individually revocable.
+  accessTokenTTL: 86400,
+  // This provider defaults refresh tokens to 30 days and dynamically-registered clients to
+  // 90 days; letting either expire forces every MCP client to re-run the full browser
+  // authorization once the window lapses. Pin both to `undefined` (never expire) so refresh
+  // keeps sessions alive indefinitely. Do NOT "simplify" these away — omitting them re-enables
+  // the 30d/90d defaults and reintroduces periodic re-authorization. Verified against
+  // @cloudflare/workers-oauth-provider 0.8.0: the constructor spreads `{ ...defaults, ...options }`
+  // and every TTL usage site gates on `!== void 0`, so an explicit `undefined` overrides the
+  // default rather than falling back to it.
   refreshTokenTTL: undefined,
   clientRegistrationTTL: undefined,
 });


### PR DESCRIPTION
## Problem

Users still report the OAuth consent screen popping up **"multiple times a day"** on `mcp.dodopayments.com` — even though the server-side OAuth fixes in #291 are **deployed and confirmed live** (0.8.0 verified on prod: `/.well-known/oauth-protected-resource` → 200, localhost-port mismatch → 200, non-localhost mismatch → clean 400).

## Root cause (client-side, but with a server-side lever)

The `dodo-agent-plugin` has no custom auth code — it spawns `npx -y mcp-remote@latest`, so all token handling is delegated to `mcp-remote`. `mcp-remote` **does not compute/store `expires_at`** ([geelen/mcp-remote#273](https://github.com/geelen/mcp-remote/issues/273), fix PR [#290](https://github.com/geelen/mcp-remote/pull/290) unmerged): it keeps sending the access token until the **server 401s**, then opens a browser tab instead of refreshing cleanly in time — and the host often kills the process before the flow completes.

Our **1h access-token TTL** makes the server 401 **~24×/day** per active client, maximizing how often that broken refresh path fires. That's the "multiple times a day."

## Change

`accessTokenTTL: 3600 → 86400` (24h). The server now 401s **~1×/day**, so mcp-remote's broken refresh path fires ~24× less often.

- **Security:** refresh tokens here are already **non-expiring**, so a longer access token does not materially change standing exposure; grants remain individually revocable via `revokeExistingGrants`. 24h is the conservative step (vs. 7d/30d) — biggest UX win for the smallest leak-window increase.
- **Scope:** server-side mitigation that ships with **no client update**. It does not fix mcp-remote's missing-`expires_at` bug or the version-scoped token-cache bug ([#200](https://github.com/geelen/mcp-remote/issues/200)) — it makes them fire far less often.

## Durable client-side fix (tracked separately)

Pin `mcp-remote` to an exact version + set a stable `MCP_REMOTE_CONFIG_DIR` in `dodo-agent-plugin`'s `.mcp.json` / `opencode-plugin/index.js`. That eliminates the version-churn cache-orphaning root cause and avoids the 0.1.38 `invalid_client` regression ([#234](https://github.com/geelen/mcp-remote/issues/234)).

## Verification (local `wrangler dev`)

- Token response `expires_in: 86400` on both `authorization_code` and `refresh_token` grants.
- No regressions: token reuse across fresh MCP sessions (200), refresh (200), rotation window (stale RT → `invalid_grant`), redirect-mismatch (200), unknown client (401), grant revocation on re-auth (401), baseline `list`/`execute`.
- `tsc --noEmit` + Prettier clean.
