### PR TITLE
fix(mcp): make code tool Deno resolution cross-platform and fail honestly on Windows

### DIFF
--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -82,11 +82,17 @@ The `execute` tool runs your code in a local [Deno](https://deno.land) sandbox, 
 available. The server looks for it in this order:
 
 1. A `deno` binary on your `PATH`.
-2. A `deno` binary provided by the [`deno` npm package](https://www.npmjs.com/package/deno),
-   if you have run `npm install deno`.
+2. A `deno` binary from the [`deno` npm package](https://www.npmjs.com/package/deno), when it is
+   installed into the same `node_modules` tree as this package.
 
 If neither is found, the `execute` tool returns an error while every other tool, including
 documentation search, keeps working.
+
+> [!NOTE]
+> Step 2 does not apply when you launch the server with `npx` or install it globally, because the
+> server then resolves from its own cache directory rather than from your project. Since
+> `npx -y dodopayments-mcp` is the most common way to run it, installing Deno on your `PATH` is the
+> recommended setup.
 
 > [!IMPORTANT]
 > Local code execution is supported on **macOS and Linux only**. It does not work on Windows,

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -76,6 +76,26 @@ isolated sandbox. To accomplish this, the server will expose two tools to your a
 Using this scheme, agents are capable of performing very complex tasks deterministically
 and repeatably.
 
+### Requirements for the code tool
+
+The `execute` tool runs your code in a local [Deno](https://deno.land) sandbox, so Deno must be
+available. The server looks for it in this order:
+
+1. A `deno` binary on your `PATH`.
+2. A `deno` binary provided by the [`deno` npm package](https://www.npmjs.com/package/deno),
+   if you have run `npm install deno`.
+
+If neither is found, the `execute` tool returns an error while every other tool, including
+documentation search, keeps working.
+
+> [!IMPORTANT]
+> Local code execution is supported on **macOS and Linux only**. It does not work on Windows,
+> because the sandbox communicates with the Deno subprocess over a Unix domain socket and Deno
+> cannot listen on one when running on Windows (see
+> [denoland/deno#18236](https://github.com/denoland/deno/issues/18236)). Installing Deno does not
+> change this. On Windows, run the server under WSL2, or call the REST API or the `dodopayments`
+> SDK directly.
+
 ## Running remotely
 
 Launching the client with `--transport=http` launches the server as a remote server using Streamable HTTP transport. The `--port` setting can choose the port it will run on, and the `--socket` setting allows it to run on a Unix socket.

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -94,6 +94,12 @@ documentation search, keeps working.
 > `npx -y dodopayments-mcp` is the most common way to run it, installing Deno on your `PATH` is the
 > recommended setup.
 
+> [!WARNING]
+> Use **Deno 2.8 or earlier** for now. On Deno 2.9+ the sandbox fails to start, because binding the
+> worker's Unix socket began requiring `--allow-net` permission for that socket, which the worker
+> does not grant. Note that `npm install deno` currently installs an affected version. Tracked in
+> [#330](https://github.com/dodopayments/dodopayments-typescript/issues/330).
+
 > [!IMPORTANT]
 > Local code execution is supported on **macOS and Linux only**. It does not work on Windows,
 > because the sandbox communicates with the Deno subprocess over a Unix domain socket and Deno

--- a/packages/mcp-server/jest.config.ts
+++ b/packages/mcp-server/jest.config.ts
@@ -4,11 +4,22 @@ const config: JestConfigWithTsJest = {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   transform: {
+    // `.cts` is not matched by the pattern below and swc infers plain JS from the extension,
+    // so it needs an explicit TypeScript parser.
+    '^.+\\.[cm]ts$': [
+      '@swc/jest',
+      { sourceMaps: 'inline', jsc: { parser: { syntax: 'typescript' } }, module: { type: 'commonjs' } },
+    ],
     '^.+\\.(t|j)sx?$': ['@swc/jest', { sourceMaps: 'inline' }],
   },
+  moduleFileExtensions: ['js', 'mjs', 'cjs', 'jsx', 'ts', 'mts', 'cts', 'tsx', 'json', 'node'],
   moduleNameMapper: {
     '^dodopayments-mcp$': '<rootDir>/src/index.ts',
     '^dodopayments-mcp/(.*)$': '<rootDir>/src/$1',
+    // Mirror the TypeScript `.cjs` -> `.cts` extension substitution that `moduleResolution:
+    // node` performs at compile time, so the CommonJS shim is reachable from tests. Scoped to
+    // this one module so it cannot rewrite `.cjs` specifiers inside third-party packages.
+    'code-tool-paths\\.cjs$': '<rootDir>/src/code-tool-paths.cts',
   },
   modulePathIgnorePatterns: ['<rootDir>/dist/'],
   testPathIgnorePatterns: ['scripts'],

--- a/packages/mcp-server/src/code-tool-paths.cts
+++ b/packages/mcp-server/src/code-tool-paths.cts
@@ -13,12 +13,22 @@ export function getWorkerPath(): string {
  * `require.resolve`'s parent `node_modules` walk to find it. `deno` declares no `exports`
  * map, so resolving a deep path into it is legal.
  *
+ * Resolution is anchored at this file, so it only sees `deno` when installed into the same
+ * `node_modules` tree as this package. Under `npx` or a global install it will not find a
+ * `deno` living in the user's own project, which is intentional: resolving from the launch
+ * directory would let any directory the server happens to start in supply the executable
+ * that gets spawned.
+ *
+ * `resolveModule` exists so tests can anchor resolution at a fixture tree.
+ *
  * Returns `null` when no usable executable is available.
  */
-export function getBundledDenoPath(): string | null {
+export function getBundledDenoPath(
+  resolveModule: (specifier: string) => string = (specifier) => require.resolve(specifier),
+): string | null {
   let launcherPath: string;
   try {
-    launcherPath = require.resolve('deno/bin.cjs');
+    launcherPath = resolveModule('deno/bin.cjs');
   } catch {
     return null;
   }
@@ -34,7 +44,18 @@ export function getBundledDenoPath(): string | null {
     process.platform === 'win32' ? 'deno.exe' : 'deno',
   );
   if (fs.existsSync(executablePath)) {
-    return executablePath;
+    // The executable bit carries no meaning on Windows, so existence is the only signal
+    // there. On POSIX an interrupted install can leave the hard-link non-executable; fall
+    // through to the launcher rather than failing later with a spawn EACCES.
+    if (process.platform === 'win32') {
+      return executablePath;
+    }
+    try {
+      fs.accessSync(executablePath, fs.constants.X_OK);
+      return executablePath;
+    } catch {
+      // Present but not executable.
+    }
   }
 
   // Fall back to the launcher, which installs the binary on first run. It relies on its

--- a/packages/mcp-server/src/code-tool-paths.cts
+++ b/packages/mcp-server/src/code-tool-paths.cts
@@ -3,3 +3,41 @@
 export function getWorkerPath(): string {
   return require.resolve('./code-tool-worker.mjs');
 }
+
+/**
+ * Resolves a Deno executable from the optional `deno` npm package, if it is installed.
+ *
+ * This deliberately uses a bare specifier rather than joining paths by hand: package
+ * managers hoist `deno` to a *sibling* of this package (e.g. `<root>/node_modules/deno`,
+ * not `<root>/node_modules/dodopayments-mcp/node_modules/deno`), so we need
+ * `require.resolve`'s parent `node_modules` walk to find it. `deno` declares no `exports`
+ * map, so resolving a deep path into it is legal.
+ *
+ * Returns `null` when no usable executable is available.
+ */
+export function getBundledDenoPath(): string | null {
+  let launcherPath: string;
+  try {
+    launcherPath = require.resolve('deno/bin.cjs');
+  } catch {
+    return null;
+  }
+
+  const fs = require('node:fs') as typeof import('node:fs');
+  const path = require('node:path') as typeof import('node:path');
+
+  // The `deno` package's postinstall hard-links the real binary next to `bin.cjs`.
+  // Prefer it: `bin.cjs` is a Node wrapper that runs Deno via a blocking `spawnSync`,
+  // so the Deno grandchild would outlive `worker.terminate()`.
+  const executablePath = path.join(
+    path.dirname(launcherPath),
+    process.platform === 'win32' ? 'deno.exe' : 'deno',
+  );
+  if (fs.existsSync(executablePath)) {
+    return executablePath;
+  }
+
+  // Fall back to the launcher, which installs the binary on first run. It relies on its
+  // shebang, so it is only directly spawnable on non-Windows platforms.
+  return process.platform === 'win32' ? null : launcherPath;
+}

--- a/packages/mcp-server/src/code-tool.ts
+++ b/packages/mcp-server/src/code-tool.ts
@@ -117,6 +117,8 @@ export function codeTool({
   return { metadata, tool, handler };
 }
 
+let denoFoundOnPath = false;
+
 const localDenoHandler = async ({
   reqContext,
   args,
@@ -163,17 +165,27 @@ const localDenoHandler = async ({
 
   // `code-tool-worker.mjs` is emitted at the package root, so this is the package directory.
   const packageDir = path.dirname(workerPath);
-  // Overshoots into the enclosing `node_modules` when installed. Must stay that way: the
-  // `--allow-read` grant below relies on this exact value to make the workspace-linked SDK
-  // readable to the sandbox in a monorepo checkout.
+  // Deliberately one level above the package. The `--allow-read` grant below depends on
+  // this exact value, and it means something different per layout: in a monorepo checkout
+  // it is what makes the workspace-linked SDK readable, while in the `.mcpb` bundle it
+  // resolves to the parent of the extracted bundle directory. Narrowing it would break the
+  // former, so weigh both before changing it.
   const workerParentDir = path.resolve(packageDir, '..');
 
   // Check if deno is in PATH. `command -v` is a POSIX shell builtin and `execSync` runs
   // under `cmd.exe` on Windows, so probe by spawning the binary directly instead: libuv
   // applies PATHEXT, and a successful run also proves the binary is actually usable.
-  const { spawnSync } = await import('node:child_process');
-  const denoProbe = spawnSync('deno', ['--version'], { stdio: 'ignore', windowsHide: true });
-  if (!denoProbe.error && denoProbe.status === 0) {
+  //
+  // The probe starts Deno and blocks the event loop while it runs, so only a positive
+  // result is cached. Caching a negative would force a restart on the most likely recovery
+  // path: hitting the error below, installing Deno, and retrying.
+  if (!denoFoundOnPath) {
+    const { spawnSync } = await import('node:child_process');
+    const denoProbe = spawnSync('deno', ['--version'], { stdio: 'ignore', windowsHide: true });
+    denoFoundOnPath = !denoProbe.error && denoProbe.status === 0;
+  }
+
+  if (denoFoundOnPath) {
     denoPath = 'deno';
   } else {
     // Use the deno binary from the `deno` npm package if it's installed.

--- a/packages/mcp-server/src/code-tool.ts
+++ b/packages/mcp-server/src/code-tool.ts
@@ -124,11 +124,35 @@ const localDenoHandler = async ({
   reqContext: McpRequestContext;
   args: unknown;
 }): Promise<ToolCallResult> => {
+  // `@valtown/deno-http-worker` talks to the Deno subprocess exclusively over a Unix
+  // domain socket. Deno cannot listen on one when running on Windows: `op_net_listen_unix`
+  // is stubbed out as unsupported on non-unix targets, because the underlying
+  // `tokio::net::UnixListener` is `#[cfg(unix)]`-gated. Node's side is blocked too, since
+  // libuv maps `net.connect({ path })` to named pipes on Windows.
+  //
+  // So local execution is structurally impossible here, not merely unimplemented. Fail
+  // fast with an honest message rather than sending users to install a Deno that could
+  // never work. Remove this guard once https://github.com/denoland/deno/issues/18236 lands
+  // and the worker gains a Windows transport.
+  if (process.platform === 'win32') {
+    return asErrorResult(
+      'Local code execution is not available on Windows.\n\n' +
+        'The sandbox runs your code in a Deno subprocess and communicates with it over a ' +
+        'Unix domain socket, which Deno cannot listen on when running on Windows ' +
+        '(see https://github.com/denoland/deno/issues/18236). Installing Deno will not ' +
+        'resolve this.\n\n' +
+        'Workarounds:\n' +
+        '  - Run this MCP server inside WSL2, where local execution works normally.\n' +
+        '  - Call the Dodo Payments REST API or the `dodopayments` SDK directly.\n\n' +
+        'Other tools on this server, such as documentation search, are unaffected.',
+    );
+  }
+
   const fs = await import('node:fs');
   const path = await import('node:path');
   const url = await import('node:url');
   const { newDenoHTTPWorker } = await import('@valtown/deno-http-worker');
-  const { getWorkerPath } = await import('./code-tool-paths.cjs');
+  const { getWorkerPath, getBundledDenoPath } = await import('./code-tool-paths.cjs');
   const workerPath = getWorkerPath();
 
   const client = reqContext.client;
@@ -137,44 +161,57 @@ const localDenoHandler = async ({
 
   let denoPath: string;
 
-  const packageRoot = path.resolve(path.dirname(workerPath), '..');
-  const packageNodeModulesPath = path.resolve(packageRoot, 'node_modules');
+  // `code-tool-worker.mjs` is emitted at the package root, so this is the package directory.
+  const packageDir = path.dirname(workerPath);
+  // Overshoots into the enclosing `node_modules` when installed. Must stay that way: the
+  // `--allow-read` grant below relies on this exact value to make the workspace-linked SDK
+  // readable to the sandbox in a monorepo checkout.
+  const workerParentDir = path.resolve(packageDir, '..');
 
-  // Check if deno is in PATH
-  const { execSync } = await import('node:child_process');
-  try {
-    execSync('command -v deno', { stdio: 'ignore' });
+  // Check if deno is in PATH. `command -v` is a POSIX shell builtin and `execSync` runs
+  // under `cmd.exe` on Windows, so probe by spawning the binary directly instead: libuv
+  // applies PATHEXT, and a successful run also proves the binary is actually usable.
+  const { spawnSync } = await import('node:child_process');
+  const denoProbe = spawnSync('deno', ['--version'], { stdio: 'ignore', windowsHide: true });
+  if (!denoProbe.error && denoProbe.status === 0) {
     denoPath = 'deno';
-  } catch {
-    try {
-      // Use deno binary in node_modules if it's found
-      const denoNodeModulesPath = path.resolve(packageNodeModulesPath, 'deno', 'bin.cjs');
-      await fs.promises.access(denoNodeModulesPath, fs.constants.X_OK);
-      denoPath = denoNodeModulesPath;
-    } catch {
+  } else {
+    // Use the deno binary from the `deno` npm package if it's installed.
+    const bundledDenoPath = getBundledDenoPath();
+    if (bundledDenoPath === null) {
       return asErrorResult(
         'Deno is required for code execution but was not found. ' +
           'Install it from https://deno.land or run: npm install deno',
       );
     }
+    denoPath = bundledDenoPath;
   }
 
   const allowReadPaths = [
     'code-tool-worker.mjs',
     `${workerPath.replace(/([\/\\]node_modules)[\/\\].+$/, '$1')}/`,
-    packageRoot,
+    workerParentDir,
   ];
 
-  // Follow symlinks in node_modules to allow read access to workspace-linked packages
-  try {
-    const sdkPkgName = 'dodopayments';
-    const sdkDir = path.resolve(packageNodeModulesPath, sdkPkgName);
-    const realSdkDir = fs.realpathSync(sdkDir);
-    if (realSdkDir !== sdkDir) {
-      allowReadPaths.push(realSdkDir);
+  // Follow symlinks in node_modules to allow read access to workspace-linked packages.
+  // The SDK sits in a different place per layout: nested inside the package for the .mcpb
+  // bundle, hoisted alongside it for a normal install, and under the package's own
+  // node_modules in a monorepo checkout.
+  const sdkPkgName = 'dodopayments';
+  for (const sdkDir of [
+    path.resolve(packageDir, 'node_modules', sdkPkgName),
+    path.resolve(workerParentDir, sdkPkgName),
+    path.resolve(workerParentDir, 'node_modules', sdkPkgName),
+  ]) {
+    try {
+      const realSdkDir = fs.realpathSync(sdkDir);
+      if (realSdkDir !== sdkDir) {
+        allowReadPaths.push(realSdkDir);
+      }
+      break;
+    } catch {
+      // Not this layout; try the next candidate.
     }
-  } catch {
-    // Ignore if symlink resolution fails
   }
 
   const allowRead = allowReadPaths.join(',');

--- a/packages/mcp-server/src/code-tool.ts
+++ b/packages/mcp-server/src/code-tool.ts
@@ -215,14 +215,18 @@ const localDenoHandler = async ({
     path.resolve(workerParentDir, sdkPkgName),
     path.resolve(workerParentDir, 'node_modules', sdkPkgName),
   ]) {
+    let realSdkDir: string;
     try {
-      const realSdkDir = fs.realpathSync(sdkDir);
-      if (realSdkDir !== sdkDir) {
-        allowReadPaths.push(realSdkDir);
-      }
-      break;
+      realSdkDir = fs.realpathSync(sdkDir);
     } catch {
-      // Not this layout; try the next candidate.
+      continue;
+    }
+    // A candidate that is a real directory already sits inside a granted path and needs no
+    // grant of its own, so keep looking: stopping at it would let it shadow a symlinked
+    // candidate further down the list, silently costing the sandbox its SDK access.
+    if (realSdkDir !== sdkDir) {
+      allowReadPaths.push(realSdkDir);
+      break;
     }
   }
 

--- a/packages/mcp-server/src/code-tool.ts
+++ b/packages/mcp-server/src/code-tool.ts
@@ -178,9 +178,11 @@ const localDenoHandler = async ({
   //
   // The probe starts Deno and blocks the event loop while it runs, so only a positive
   // result is cached. Caching a negative would force a restart on the most likely recovery
-  // path: hitting the error below, installing Deno, and retrying.
+  // path: hitting the error below, installing Deno, and retrying. The import stays above the
+  // check so that nothing awaits between reading and writing the cache, which would let
+  // concurrent calls each start their own probe.
+  const { spawnSync } = await import('node:child_process');
   if (!denoFoundOnPath) {
-    const { spawnSync } = await import('node:child_process');
     const denoProbe = spawnSync('deno', ['--version'], { stdio: 'ignore', windowsHide: true });
     denoFoundOnPath = !denoProbe.error && denoProbe.status === 0;
   }

--- a/packages/mcp-server/tests/code-tool.test.ts
+++ b/packages/mcp-server/tests/code-tool.test.ts
@@ -1,4 +1,9 @@
+import { createRequire } from 'node:module';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { codeTool } from '../src/code-tool';
+import { getBundledDenoPath } from '../src/code-tool-paths.cjs';
 import { configureLogger } from '../src/logger';
 import type { McpRequestContext, ToolCallResult } from '../src/types';
 
@@ -44,22 +49,88 @@ describe('codeTool execute handler', () => {
     }
   });
 
-  it('blocks forbidden methods before reaching platform detection', async () => {
+  it('rejects blocked methods before attempting any execution', async () => {
+    const handler = codeTool({
+      blockedMethods: [{ fullyQualifiedName: 'client.payments.create' } as any],
+      codeExecutionMode: 'local',
+    }).handler;
+
+    const result = await handler({
+      reqContext,
+      args: { code: 'await client.payments.create({})' },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(textOf(result)).toContain('client.payments.create');
+  });
+});
+
+describe('getBundledDenoPath', () => {
+  let fixtureDir: string;
+
+  const anchoredResolve = () => {
+    const anchoredRequire = createRequire(path.join(fixtureDir, 'anchor.cjs'));
+    return (specifier: string) => anchoredRequire.resolve(specifier);
+  };
+
+  const writeDenoPackage = ({ withExecutable }: { withExecutable: boolean }) => {
+    const denoDir = path.join(fixtureDir, 'node_modules', 'deno');
+    fs.mkdirSync(denoDir, { recursive: true });
+    fs.writeFileSync(path.join(denoDir, 'package.json'), '{"name":"deno","version":"0.0.0"}');
+    fs.writeFileSync(path.join(denoDir, 'bin.cjs'), '#!/usr/bin/env node\n');
+    if (withExecutable) {
+      const executablePath = path.join(denoDir, process.platform === 'win32' ? 'deno.exe' : 'deno');
+      fs.writeFileSync(executablePath, '#!/bin/sh\necho "deno 0.0.0"\n');
+      fs.chmodSync(executablePath, 0o755);
+    }
+    return denoDir;
+  };
+
+  beforeEach(() => {
+    // realpath so comparisons hold on macOS, where tmpdir is a /var -> /private/var symlink
+    // and `require.resolve` returns the resolved path.
+    fixtureDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'dodo-deno-fixture-')));
+  });
+
+  afterEach(() => {
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  it('returns null when the deno package is not installed', () => {
+    expect(getBundledDenoPath(anchoredResolve())).toBeNull();
+  });
+
+  it('resolves deno hoisted as a sibling package, not under a nested node_modules', () => {
+    const denoDir = writeDenoPackage({ withExecutable: true });
+
+    const resolved = getBundledDenoPath(anchoredResolve());
+
+    expect(resolved).toBe(path.join(denoDir, process.platform === 'win32' ? 'deno.exe' : 'deno'));
+    expect(resolved).not.toContain(`node_modules${path.sep}node_modules`);
+  });
+
+  it('falls back to the launcher when the native binary is missing', () => {
+    const denoDir = writeDenoPackage({ withExecutable: false });
+
+    expect(getBundledDenoPath(anchoredResolve())).toBe(path.join(denoDir, 'bin.cjs'));
+  });
+
+  it('falls back to the launcher when the native binary is not executable', () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+    const denoDir = writeDenoPackage({ withExecutable: true });
+    fs.chmodSync(path.join(denoDir, 'deno'), 0o644);
+
+    expect(getBundledDenoPath(anchoredResolve())).toBe(path.join(denoDir, 'bin.cjs'));
+  });
+
+  it('returns null on Windows when only the shebang launcher is available', () => {
+    writeDenoPackage({ withExecutable: false });
     const restorePlatform = mockPlatform('win32');
 
     try {
-      const handler = codeTool({
-        blockedMethods: [{ fullyQualifiedName: 'client.payments.create' } as any],
-        codeExecutionMode: 'local',
-      }).handler;
-
-      const result = await handler({
-        reqContext,
-        args: { code: 'await client.payments.create({})' },
-      });
-
-      expect(result.isError).toBe(true);
-      expect(textOf(result)).toContain('client.payments.create');
+      expect(getBundledDenoPath(anchoredResolve())).toBeNull();
     } finally {
       restorePlatform();
     }

--- a/packages/mcp-server/tests/code-tool.test.ts
+++ b/packages/mcp-server/tests/code-tool.test.ts
@@ -1,0 +1,67 @@
+import { codeTool } from '../src/code-tool';
+import { configureLogger } from '../src/logger';
+import type { McpRequestContext, ToolCallResult } from '../src/types';
+
+const mockPlatform = (platform: NodeJS.Platform) => {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  Object.defineProperty(process, 'platform', { ...original, value: platform });
+  return () => {
+    Object.defineProperty(process, 'platform', original);
+  };
+};
+
+const textOf = (result: ToolCallResult): string =>
+  result.content.map((block) => (block.type === 'text' ? block.text : '')).join('\n');
+
+const reqContext = {
+  client: { baseURL: 'https://test.dodopayments.com' },
+} as unknown as McpRequestContext;
+
+const executeHandler = () => codeTool({ blockedMethods: undefined, codeExecutionMode: 'local' }).handler;
+
+describe('codeTool execute handler', () => {
+  beforeAll(() => {
+    configureLogger({ level: 'error', pretty: false });
+  });
+
+  it('reports the real Windows limitation instead of asking the user to install Deno', async () => {
+    const restorePlatform = mockPlatform('win32');
+
+    try {
+      const result = await executeHandler()({
+        reqContext,
+        args: { code: 'async function run(client) {}' },
+      });
+
+      expect(result.isError).toBe(true);
+      const message = textOf(result);
+      expect(message).toContain('not available on Windows');
+      expect(message).toContain('https://github.com/denoland/deno/issues/18236');
+      // The old message sent Windows users to install Deno, which can never fix this.
+      expect(message).not.toMatch(/npm install deno/);
+    } finally {
+      restorePlatform();
+    }
+  });
+
+  it('blocks forbidden methods before reaching platform detection', async () => {
+    const restorePlatform = mockPlatform('win32');
+
+    try {
+      const handler = codeTool({
+        blockedMethods: [{ fullyQualifiedName: 'client.payments.create' } as any],
+        codeExecutionMode: 'local',
+      }).handler;
+
+      const result = await handler({
+        reqContext,
+        args: { code: 'await client.payments.create({})' },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(textOf(result)).toContain('client.payments.create');
+    } finally {
+      restorePlatform();
+    }
+  });
+});


### PR DESCRIPTION
Fixes #327.

Thanks @charlycrates — the report was accurate and unusually well researched. I reproduced and verified all three layers, and found that layer 2 is actually worse than reported: it breaks on **every** platform, not just Windows.

## What was broken

### Layer 1 — Deno detection was POSIX-only

`execSync('command -v deno')` runs under `cmd.exe` on Windows, which has no `command` builtin, so detection threw unconditionally regardless of whether Deno was installed. **Confirmed.**

### Layer 2 — the node_modules fallback probed a path that never exists (all platforms)

I unpacked the published `dodopayments-mcp@2.45.0` tarball: `code-tool-worker.mjs` sits at the **package root**, so `path.dirname(workerPath)` already *is* the package root and `path.resolve(..., '..')` overshoots into the enclosing `node_modules`.

Demonstrated against a simulated hoisted install layout, on macOS:

```
workerPath            : .../node_modules/dodopayments-mcp/code-tool-worker.mjs
OLD probed path       : .../node_modules/node_modules/deno/bin.cjs
OLD found deno?       : false          <-- never exists, on any OS
NEW resolved path     : .../node_modules/deno/deno
NEW found deno?       : true
NEW picked native exe : true
```

So the `npm install deno` path in the error message could never work for anyone. The same off-by-one also broke workspace-symlink resolution for the SDK in **installed layouts** (published install and `.mcpb`), where `realpathSync` threw into a swallowed `catch` and contributed no grant.

Two further details: package managers **hoist** `deno` to a *sibling* of this package, so fixing the `'..'` alone still wouldn't find it — resolution has to go through `require.resolve`. And `bin.cjs` is a Node launcher, not a binary; on Windows spawning it fails, and `X_OK` is meaningless there so the guard would have passed before failing at spawn.

### Layer 3 — Unix-socket transport (structural)

`@valtown/deno-http-worker` communicates with Deno exclusively over a Unix domain socket, at every published version including the latest `2.0.3`; there is no platform branching anywhere in its history. Deno stubs `op_net_listen_unix` as unsupported on non-unix targets because `tokio::net::UnixListener` is `#[cfg(unix)]`-gated ([denoland/deno#18236](https://github.com/denoland/deno/issues/18236), open since 2023).

It's blocked on **both** sides, which is stronger than the original report: even if Deno could bind AF_UNIX on Windows, libuv maps Node's `net.connect({ path })` to named pipes, so the host couldn't reach it. Deno's named-pipe support landed only in the `node:net`/`node:http` compat layer, not native `Deno.serve({ path })`. So this is structurally impossible today, not merely unimplemented.

## What this PR changes

- **Layer 1** — replaces the `command -v` probe with `spawnSync('deno', ['--version'])`. libuv applies PATHEXT, and a successful run also proves the binary is usable. `shell` is deliberately **not** set: with `shell: true` a `deno.cmd` shim would pass detection and then fail at spawn time inside `newDenoHTTPWorker`, trading a clear message for a cryptic one. The result is memoized positive-only, since the probe starts Deno and blocks the event loop.
- **Layer 2** — resolves the bundled Deno via `require.resolve('deno/bin.cjs')` (bare specifier, so Node's parent-`node_modules` walk handles hoisting) and prefers the native binary that deno's postinstall hard-links next to the launcher. That also avoids an orphaned-process leak: `bin.cjs` wraps Deno in a blocking `spawnSync`, so its grandchild would outlive `worker.terminate()`. Also replaces the single symlink guess with a candidate list covering the `.mcpb` bundle, hoisted-install, and monorepo layouts — which additionally fixes pnpm.
- **Layer 3** — guards on `win32` and states the real constraint, with WSL2 and direct SDK/REST as workarounds. Placed before the worker import, so Windows never even loads the Unix-socket library.
- **Docs** — the README never mentioned Deno at all. Adds a requirements section covering the lookup order and the macOS/Linux-only limitation, including the caveat that npm-package resolution does not apply under `npx` or a global install.

### Deliberately unchanged

The `--allow-read` array is byte-identical. The variable it depends on looks wrong (it overshoots into `node_modules`) but is load-bearing, and it means something different per layout: in a monorepo checkout it is the only grant that makes the workspace-linked SDK readable, while under `.mcpb` it resolves to the parent of the extracted bundle directory. Narrowing it would break the former, so both cases need weighing before anyone changes it. It's renamed to `workerParentDir` and commented accordingly.

## Verification

- `tsc --noEmit` clean; `eslint` and `prettier --check` clean.
- `yarn build` succeeds end to end, including the signed `.mcpb` bundle.
- Jest 9/9 passing, all new — this file previously had no tests at all.
- **Negative controls** for the three behaviours most likely to regress:

  | Reverted behaviour | Test that fails |
  | --- | --- |
  | win32 guard | `reports the real Windows limitation...` |
  | native-binary preference | `resolves deno hoisted as a sibling package...` |
  | `X_OK` gate | `falls back to the launcher when the native binary is not executable` |

- Verified the emitted `code-tool-paths.cjs` exports are `cjs-module-lexer`-detectable and that the named import works at runtime from the `.mjs` build.
- Verified with esbuild that the bare `require.resolve('deno/bin.cjs')` is left verbatim and does not break Cloudflare Worker bundling (`deno` isn't a dependency there). Consistent with `patch-deps.js`, which notes the CF path never exercises this code at runtime.

Windows users get a correct, actionable message today; layers 1 and 2 mean the fix is already correct on macOS/Linux and will work on Windows unchanged the day the transport gap closes.

> Worth flagging upstream to Stainless: layer 2 looks like a generic template bug, so every Stainless-generated MCP server with a code tool likely has the same dead fallback. Carrying the patch locally means a future regeneration could silently revert it, which is exactly why the `getBundledDenoPath` tests matter.

---

<details>
<summary><b>Review round 2</b> — four non-blocking notes addressed</summary>

- **Memoized the PATH probe**, positive-only. Caching a negative would force a restart on the most likely recovery path (hit the error, install Deno, retry).
- **Restored the `X_OK` check on POSIX**, gated on platform so Windows correctness is kept. A present-but-non-executable hard-link now falls through to the launcher instead of failing later as a spawn `EACCES`.
- **Documented the npx/global-install gap.** Fixing it in code was considered and rejected: resolving from `process.cwd()` would let any launch directory supply the executable that gets spawned.
- **Added `getBundledDenoPath` tests** — the part that rotted silently, so the part most likely to regress. This surfaced that the `.cts` shim was unreachable from Jest entirely (`.cts` isn't matched by the transform pattern, swc infers plain JS from the extension, and Jest doesn't do the `.cjs` → `.cts` substitution that `moduleResolution: node` does at compile time), which is a large part of why this went unnoticed for so long.

Two corrections to the original description, both now folded in above: the swallowed-`catch` breakage was specific to installed layouts rather than universal (the monorepo guess did resolve correctly), and the `--allow-read` note now covers the `.mcpb` case alongside the monorepo one.

</details>
