### PR TITLE
ci: run the test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,31 @@ jobs:
 
       - name: Check build
         run: ./scripts/build
+
+  test:
+    timeout-minutes: 10
+    name: test
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Bootstrap
+        run: ./scripts/bootstrap
+
+      - name: Run tests
+        run: ./scripts/test
+
+      # Sub-packages are not workspaces, so they carry their own dependencies and test
+      # runner. Scripts are skipped because the package's `prepare` hook builds against the
+      # linked root SDK, which the tests do not need: they run against `src` directly.
+      - name: Install sub-package dependencies
+        run: yarn --cwd packages/mcp-server install --pure-lockfile --ignore-scripts
+
+      - name: Run sub-package tests
+        run: yarn --cwd packages/mcp-server test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -78,6 +80,11 @@ jobs:
       # Sub-packages are not workspaces, so they carry their own dependencies and test
       # runner. Scripts are skipped because the package's `prepare` hook builds against the
       # linked root SDK, which the tests do not need: they run against `src` directly.
+      #
+      # These two steps must stay in this job, after Bootstrap. The sub-package's Jest config
+      # names the `@swc/jest` transform without declaring it, so it resolves only by walking
+      # up to the root `node_modules` that Bootstrap populates. Splitting them into a job of
+      # their own would break them until that dependency is declared.
       - name: Install sub-package dependencies
         run: yarn --cwd packages/mcp-server install --pure-lockfile --ignore-scripts
 


### PR DESCRIPTION
CI runs only `lint` and `build`. `scripts/test` is never invoked, so **no test in this repository is enforced on a pull request** — not the 425 root SDK tests, and not the `packages/mcp-server` suite.

I found this while verifying #328. That PR adds tests specifically to guard against a future Stainless regeneration silently reverting a fix, which does not work if nothing runs them.

Both suites pass today. Nothing was gating them; they were simply never wired up.

## What this adds

A `test` job mirroring the existing `lint`/`build` shape, covering both suites:

- **Root SDK** via `./scripts/test` — 43 suites, 425 tests. The script starts its own mock Steady server against the OpenAPI spec and tears it down on exit, so no extra CI setup is needed.
- **`packages/mcp-server`** — excluded from the root run by `modulePathIgnorePatterns: ['<rootDir>/packages/']`, so it needs its own invocation.

## Why `--ignore-scripts` on the sub-package install

Sub-packages are not yarn workspaces, so they carry their own dependencies. The package's `prepare` hook runs a build against the root SDK linked from `dist/`, which would drag a full root build into a job that does not need one.

Without the flag the install **fails outright** when `dist/` is absent:

```
[mjs]: dist/src/types.ts:3:26 - error TS2307: Cannot find module 'dodopayments'
error Command failed with exit code 1.
```

Skipping it is safe here because the tests import from `src` and reference the SDK only in type positions, which the transform erases — verified by removing the linked SDK entirely and re-running: 9/9 still pass. The `build` job already covers that the package builds.

## Verification

Replayed the job locally on Node 22 in a clean `git worktree`, from a cold start with no `node_modules` and no `dist/`:

| Step | Result |
| --- | --- |
| `./scripts/bootstrap` | exit 0 |
| `./scripts/test` | **43 suites, 425 tests, 425 passed** |
| `yarn --cwd packages/mcp-server install --pure-lockfile --ignore-scripts` | exit 0, 4.4s |
| `yarn --cwd packages/mcp-server test` | **2 suites, 9 tests, 9 passed** |

`actionlint` is clean.

One detail worth recording, since it is easy to get wrong when reproducing locally: the worktree has to sit somewhere that `scripts/utils/check-is-in-git-install.sh` reports **false**. Under `/tmp` the parent directory is literally `tmp`, which makes the script return true and fire the `prepare` build, so the run stops resembling CI. I moved it before trusting the numbers.

## Notes

- No untrusted input reaches any `run:` step. The `if:` conditions are copied verbatim from the existing `build` job for consistency.
- `timeout-minutes: 10` because the root suite takes roughly two minutes plus mock server startup.
- Kept deliberately separate from #328 so a CI change is not bundled into a bug fix, and so either can be reverted independently. Merging this first would mean #328 gets its own tests run against it.

Once this is in, it would be worth making `test` a required status check alongside `lint` and `build`.
