### PR TITLE
ci: validate the Cloudflare Worker against the repository, not npm

### DIFF
--- a/.github/workflows/ci-cloudflare-worker.yml
+++ b/.github/workflows/ci-cloudflare-worker.yml
@@ -14,19 +14,19 @@ on:
       - '!codegen/**'
       - 'codegen/stl/**'
     paths:
-      - 'packages/mcp-server/cloudflare-worker/**'
+      - 'packages/mcp-server/**'
       - '.github/workflows/ci-cloudflare-worker.yml'
   pull_request:
     branches-ignore:
       - 'stl-preview-head/**'
       - 'stl-preview-base/**'
     paths:
-      - 'packages/mcp-server/cloudflare-worker/**'
+      - 'packages/mcp-server/**'
       - '.github/workflows/ci-cloudflare-worker.yml'
 
 jobs:
   worker:
-    timeout-minutes: 10
+    timeout-minutes: 20
     name: typecheck and build
     runs-on: ubuntu-latest
     defaults:
@@ -42,6 +42,26 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+
+      # The Worker declares `dodopayments` and `dodopayments-mcp` as `latest`, so without
+      # this it would validate whatever is on npm rather than this commit, and a change to
+      # `packages/mcp-server/src` that breaks the Worker would only surface after release.
+      # `src/execute-tool.ts` imports `dodopayments-mcp/code-tool` directly, so that is a
+      # real exposure rather than a theoretical one.
+      - name: Build the packages from this commit
+        working-directory: ${{ github.workspace }}
+        run: |
+          yarn install
+          ./scripts/build
+
+      # `patch-deps.js` rewrites files inside the installed package, so it has to run again
+      # against the build that just replaced it.
+      - name: Validate against the local build instead of the published packages
+        run: |
+          rm -rf node_modules/dodopayments node_modules/dodopayments-mcp
+          cp -R "$GITHUB_WORKSPACE/dist" node_modules/dodopayments
+          cp -R "$GITHUB_WORKSPACE/packages/mcp-server/dist" node_modules/dodopayments-mcp
+          node scripts/patch-deps.js
 
       - name: Build isolate bundle
         run: npm run build:isolate


### PR DESCRIPTION
The Cloudflare Worker's CI had two blind spots which, combined, meant **a change to the package it imports from could not fail its build**.

Found while verifying #328. That PR modifies `packages/mcp-server/src/code-tool.ts`, and `cloudflare-worker/src/execute-tool.ts` imports that module *directly*:

```ts
import { codeTool } from 'dodopayments-mcp/code-tool';
```

Yet the `typecheck and build` job never ran on #328, and would not have tested those changes even if it had. I ended up validating the Worker by hand.

## Blind spot 1 — the path filter excluded the source

The trigger only matched `packages/mcp-server/cloudflare-worker/**`, so changes under `packages/mcp-server/src` never started the job. Widened to `packages/mcp-server/**`, which still covers the Worker's own directory.

## Blind spot 2 — it validated npm, not the checkout

More significant, and the reason widening the filter alone is not enough. The Worker declares both dependencies as `latest`:

```json
"dodopayments-mcp": "latest",
"dodopayments": "latest"
```

So the job resolved them from the registry and validated **the last release rather than the commit under test**. A Worker-breaking change would have gone green through review and only surfaced after shipping.

The job now builds both packages from the checkout and validates against those. `patch-deps.js` runs a second time because it rewrites files inside the installed package, which the copy replaces.

I deliberately did not change `package.json` to a `file:` dependency. That would alter how the Worker is deployed for real, which is a much larger blast radius than making CI honest — this keeps the change confined to CI.

## Verification

Replayed the whole job on Node 22 in a clean worktree, placed so `check-is-in-git-install.sh` reports false (matching a CI checkout rather than triggering the `prepare` build):

| Step | Result |
| --- | --- |
| `npm install` | exit 0 |
| `yarn install && ./scripts/build` | exit 0, both `dist/` and `packages/mcp-server/dist/` produced |
| swap + `patch-deps.js` | exit 0, all four files patched |
| `npm run build:isolate` | 151069 bytes bundled |
| `npm run typecheck` | clean |
| `npx wrangler deploy --dry-run` | success, all bindings resolved |

**Confirmed the job has teeth**, since a check that cannot fail is worse than no check. Removing the `code-tool` declarations from the built package makes typecheck fail precisely where it should, instead of passing silently:

```
src/execute-tool.ts(2,26): error TS7016: Could not find a declaration file for
module 'dodopayments-mcp/code-tool'
```

I also tried renaming the `codeTool` export outright; that fails earlier, at the package build step, which is the other place a break should stop.

`actionlint` and `prettier --check` are clean.

## Trade-off

The job now runs a full root build, so it is slower and fires on any `packages/mcp-server/**` change rather than Worker-only edits. Timeout raised from 10 to 20 minutes to cover it. That seemed clearly worth it against a check that silently could not fail — but it is the kind of cost worth agreeing on rather than assuming, so say if you would prefer it scoped more narrowly.

Independent of #328 and #329; merge in any order.
